### PR TITLE
修复issue#51存在的问题并修改相应的单元测试

### DIFF
--- a/src/plugins/nonebot_bison/config_manager.py
+++ b/src/plugins/nonebot_bison/config_manager.py
@@ -269,13 +269,16 @@ def do_del_sub(del_sub: Type[Matcher]):
             if platform.enable_tag:
                 res += " {}".format(", ".join(sub["tags"]))
             res += "\n"
-        res += "请输入要删除的订阅的序号"
+        res += "请输入要删除的订阅的序号\n输入'取消'中止"
         await bot.send(event=event, message=Message(await parse_text(res)))
 
     @del_sub.receive()
     async def do_del(event: Event, state: T_State):
+        user_msg = str(event.get_message()).strip()
+        if user_msg == "取消":
+            await del_sub.finish("删除中止")
         try:
-            index = int(str(event.get_message()).strip())
+            index = int(user_msg)
             config = Config()
             user_info = state["target_user_info"]
             assert isinstance(user_info, User)

--- a/src/plugins/nonebot_bison/config_manager.py
+++ b/src/plugins/nonebot_bison/config_manager.py
@@ -244,33 +244,38 @@ def do_del_sub(del_sub: Type[Matcher]):
         config: Config = Config()
         user_info = state["target_user_info"]
         assert isinstance(user_info, User)
-        sub_list = config.list_subscribe(
-            # state.get("_user_id") or event.group_id, "group"
-            user_info.user,
-            user_info.user_type,
-        )
-        res = "订阅的帐号为：\n"
-        state["sub_table"] = {}
-        for index, sub in enumerate(sub_list, 1):
-            state["sub_table"][index] = {
-                "target_type": sub["target_type"],
-                "target": sub["target"],
-            }
-            res += "{} {} {} {}\n".format(
-                index, sub["target_type"], sub["target_name"], sub["target"]
+        try:
+            sub_list = config.list_subscribe(
+                # state.get("_user_id") or event.group_id, "group"
+                user_info.user,
+                user_info.user_type,
             )
-            platform = platform_manager[sub["target_type"]]
-            if platform.categories:
-                res += " [{}]".format(
-                    ", ".join(
-                        map(lambda x: platform.categories[Category(x)], sub["cats"])
-                    )
+            assert sub_list
+        except AssertionError:
+            await del_sub.finish("暂无已订阅账号\n请使用“添加订阅”命令添加订阅")
+        else:
+            res = "订阅的帐号为：\n"
+            state["sub_table"] = {}
+            for index, sub in enumerate(sub_list, 1):
+                state["sub_table"][index] = {
+                    "target_type": sub["target_type"],
+                    "target": sub["target"],
+                }
+                res += "{} {} {} {}\n".format(
+                    index, sub["target_type"], sub["target_name"], sub["target"]
                 )
-            if platform.enable_tag:
-                res += " {}".format(", ".join(sub["tags"]))
-            res += "\n"
-        res += "请输入要删除的订阅的序号\n输入'取消'中止"
-        await bot.send(event=event, message=Message(await parse_text(res)))
+                platform = platform_manager[sub["target_type"]]
+                if platform.categories:
+                    res += " [{}]".format(
+                        ", ".join(
+                            map(lambda x: platform.categories[Category(x)], sub["cats"])
+                        )
+                    )
+                if platform.enable_tag:
+                    res += " {}".format(", ".join(sub["tags"]))
+                res += "\n"
+            res += "请输入要删除的订阅的序号\n输入'取消'中止"
+            await bot.send(event=event, message=Message(await parse_text(res)))
 
     @del_sub.receive()
     async def do_del(event: Event, state: T_State):

--- a/tests/test_config_manager_abort.py
+++ b/tests/test_config_manager_abort.py
@@ -281,3 +281,49 @@ async def test_abort_add_on_tag(app: App):
             True,
         )
         ctx.should_finished()
+
+
+# 删除订阅阶段中止
+@pytest.mark.asyncio
+async def test_abort_del_sub(app: App):
+    from nonebot.adapters.onebot.v11.bot import Bot
+    from nonebot.adapters.onebot.v11.message import Message
+    from nonebot_bison.config import Config
+    from nonebot_bison.config_manager import del_sub_matcher
+    from nonebot_bison.platform import platform_manager
+
+    config = Config()
+    config.user_target.truncate()
+    config.add_subscribe(
+        10000,
+        "group",
+        "6279793937",
+        "明日方舟Arknights",
+        "weibo",
+        [platform_manager["weibo"].reverse_category["图文"]],
+        ["明日方舟"],
+    )
+    async with app.test_matcher(del_sub_matcher) as ctx:
+        bot = ctx.create_bot(base=Bot)
+        assert isinstance(bot, Bot)
+        event = fake_group_message_event(
+            message=Message("删除订阅"), to_me=True, sender=fake_admin_user
+        )
+        ctx.receive_event(bot, event)
+        ctx.should_pass_rule()
+        ctx.should_pass_permission()
+        ctx.should_call_send(
+            event,
+            Message(
+                "订阅的帐号为：\n1 weibo 明日方舟Arknights 6279793937\n [图文] 明日方舟\n请输入要删除的订阅的序号\n输入'取消'中止"
+            ),
+            True,
+        )
+        event_abort = fake_group_message_event(
+            message=Message("取消"), sender=fake_admin_user
+        )
+        ctx.receive_event(bot, event_abort)
+        ctx.should_call_send(event_abort, "删除中止", True)
+        ctx.should_finished()
+    subs = config.list_subscribe(10000, "group")
+    assert subs

--- a/tests/test_config_manager_add.py
+++ b/tests/test_config_manager_add.py
@@ -387,8 +387,8 @@ async def test_add_with_get_id(app: App):
             True,
         )
         """
-        line 362:
-        鬼知道为什么要在这里这样写，
+        关于Message([MessageSegment(*BotReply.add_reply_on_id_input_search())]):
+        异客知道为什么要在这里这样写，
         没有[]的话assert不了(should_call_send使用[MessageSegment(...)]的格式进行比较)
         不在这里MessageSegment()的话也assert不了(指不能让add_reply_on_id_input_search直接返回一个MessageSegment对象)
         amen

--- a/tests/test_config_manager_query_del.py
+++ b/tests/test_config_manager_query_del.py
@@ -67,7 +67,7 @@ async def test_del_sub(app: App):
         ctx.should_call_send(
             event,
             Message(
-                "订阅的帐号为：\n1 weibo 明日方舟Arknights 6279793937\n [图文] 明日方舟\n请输入要删除的订阅的序号"
+                "订阅的帐号为：\n1 weibo 明日方舟Arknights 6279793937\n [图文] 明日方舟\n请输入要删除的订阅的序号\n输入'取消'中止"
             ),
             True,
         )

--- a/tests/test_config_manager_query_del.py
+++ b/tests/test_config_manager_query_del.py
@@ -85,3 +85,30 @@ async def test_del_sub(app: App):
         ctx.should_finished()
     subs = config.list_subscribe(10000, "group")
     assert len(subs) == 0
+
+
+@pytest.mark.asyncio
+async def test_del_empty_sub(app: App):
+    from nonebot.adapters.onebot.v11.bot import Bot
+    from nonebot.adapters.onebot.v11.message import Message
+    from nonebot_bison.config import Config
+    from nonebot_bison.config_manager import del_sub_matcher
+    from nonebot_bison.platform import platform_manager
+
+    config = Config()
+    config.user_target.truncate()
+    async with app.test_matcher(del_sub_matcher) as ctx:
+        bot = ctx.create_bot(base=Bot)
+        assert isinstance(bot, Bot)
+        event = fake_group_message_event(
+            message=Message("删除订阅"), to_me=True, sender=fake_admin_user
+        )
+        ctx.receive_event(bot, event)
+        ctx.should_pass_rule()
+        ctx.should_pass_permission()
+        ctx.should_finished()
+        ctx.should_call_send(
+            event,
+            "暂无已订阅账号\n请使用“添加订阅”命令添加订阅",
+            True,
+        )


### PR DESCRIPTION
[issue#51](https://github.com/felinae98/nonebot-bison/issues/51)
> 删除订阅似乎还没有取消的功能。最好也添加一下。

现在已经向`删除订阅`命令中添加`取消`功能
> 没有订阅的时候，删除订阅列表为空，无论输什么数字或者“取消”都跳不出

当该群没有订阅时，会直接返回"暂无已订阅账号"的消息并结束`删除订阅`命令
（进行一个删除失败的规避）