### PR TITLE
调整群内订阅命令回复文本的位置，为`后台管理`命令添加别名`管理后台`

### DIFF
--- a/src/plugins/nonebot_bison/admin_page/__init__.py
+++ b/src/plugins/nonebot_bison/admin_page/__init__.py
@@ -70,7 +70,7 @@ def init():
 if (STATIC_PATH / "index.html").exists():
     init()
 
-    get_token = on_command("后台管理", rule=to_me(), priority=5)
+    get_token = on_command("后台管理", rule=to_me(), priority=5, aliases={"管理后台"})
 
     @get_token.handle()
     async def send_token(bot: "Bot", event: PrivateMessageEvent, state: T_State):

--- a/src/plugins/nonebot_bison/config_manager.py
+++ b/src/plugins/nonebot_bison/config_manager.py
@@ -182,7 +182,7 @@ def do_add_sub(add_sub: Type[Matcher]):
         if not platform_manager[state["platform"]].enable_tag:
             state["tags"] = []
             return
-        state["_prompt"] = '请输入要订阅/屏蔽的tag(不含#号)\n多个tag请使用空格隔开\n具体规则回复"详情"'
+        state["_prompt"] = '请输入要订阅/屏蔽的标签(不含#号)\n多个标签请使用空格隔开\n订阅所有标签输入"全部标签"\n具体规则回复"详情"'
 
     async def parser_tags(event: MessageEvent, state: T_State):
         if not isinstance(state["tags"], Message):
@@ -191,9 +191,9 @@ def do_add_sub(add_sub: Type[Matcher]):
             await add_sub.finish("已中止订阅")
         if str(event.get_message()).strip() == "详情":
             await add_sub.reject(
-                '订阅tag直接输入tag内容\n订阅所有tag输入"全部标签"\n屏蔽tag请在tag名称前添加~号\n详见https://nonebot-bison.netlify.app/usage/#平台订阅标签-tag'
+                "订阅标签直接输入标签内容\n屏蔽标签请在标签名称前添加~号\n详见https://nonebot-bison.netlify.app/usage/#%E5%B9%B3%E5%8F%B0%E8%AE%A2%E9%98%85%E6%A0%87%E7%AD%BE-tag"
             )
-        if str(event.get_message()).strip() == "全部标签":
+        if str(event.get_message()).strip() in ["全部标签", "全部", "全标签"]:
             state["tags"] = []
         else:
             state["tags"] = str(event.get_message()).strip().split()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,3 @@
-from ast import Str
 from typing import TYPE_CHECKING
 
 from typing_extensions import Literal
@@ -132,7 +131,7 @@ class BotReply:
         return "添加 {} 成功".format(name)
 
     @staticmethod
-    def add_reply_on_id(platform: object) -> Str:
+    def add_reply_on_id(platform: object) -> str:
         base_text = "请输入订阅用户的id\n查询id获取方法请回复:“查询”"
         extra_text = (
             ("1." + platform.parse_target_promot + "\n2.")
@@ -144,6 +143,6 @@ class BotReply:
     add_reply_on_id_input_error = "id输入错误"
     add_reply_on_target_parse_input_error = "不能从你的输入中提取出id，请检查你输入的内容是否符合预期"
     add_reply_on_platform_input_error = "平台输入错误"
-    add_reply_on_tags = '请输入要订阅/屏蔽的tag(不含#号)\n多个tag请使用空格隔开\n具体规则回复"详情"'
-    add_reply_on_tags_need_more_info = '订阅tag直接输入tag内容\n订阅所有tag输入"全部标签"\n屏蔽tag请在tag名称前添加~号\n详见https://nonebot-bison.netlify.app/usage/#平台订阅标签-tag'
+    add_reply_on_tags = '请输入要订阅/屏蔽的标签(不含#号)\n多个标签请使用空格隔开\n订阅所有标签输入"全部标签"\n具体规则回复"详情"'
+    add_reply_on_tags_need_more_info = "订阅标签直接输入标签内容\n屏蔽标签请在标签名称前添加~号\n详见https://nonebot-bison.netlify.app/usage/#%E5%B9%B3%E5%8F%B0%E8%AE%A2%E9%98%85%E6%A0%87%E7%AD%BE-tag"
     add_reply_abort = "已中止订阅"


### PR DESCRIPTION
考虑到当在群内进行订阅过程，到达添加tag阶段时，总是记不住订阅全部标签应该回复"全部标签"这一事实
故先将"全部标签"相关提示从`详情`中移出，并将回复中的`tag`一词全部改为`标签`
顺带将`详情`网址中的汉字转义

style(config-manager): 调整订阅回复内容结构以优化群内订阅体验
style(admin-page): 为`后台管理`命令添加别名
test: 调整相关测试的文本